### PR TITLE
Define outcome-based adoption and insight metrics

### DIFF
--- a/docs/adoption-metrics.md
+++ b/docs/adoption-metrics.md
@@ -1,0 +1,61 @@
+**Adoption & Insight Metrics – Analytics Case Study**
+
+**Problem Recap**
+In analytics products, dashboard creation and views are often treated as indicators of success. However, usage alone does not guarantee insight, decision-making, or business impact.
+
+This creates a gap between **adoption** and **value**.
+
+**Metric Design Principles**
+- Metrics should reflect **outcomes**, not activity
+- Adoption must be tied to **decision-making**, not just consumption
+- Signals should discourage dashboard sprawl
+- Measurement should respect user privacy and product constraints
+**
+North Star Metric**
+**Percentage of active dashboards that lead to at least one documented decision or action within a defined time window.**
+
+**Why this metric**
+- Shifts focus from volume to impact
+- Aligns analytics usage with real-world decisions
+- Encourages higher-quality dashboards
+
+**Supporting Metrics**
+**Dashboard Re-engagement Rate**
+Percentage of dashboards viewed across multiple sessions.
+- Indicates sustained relevance
+- Filters out one-off or abandoned dashboards
+**
+Time to First Action**
+Time between dashboard creation and first meaningful action.
+- Measures speed to insight
+- Highlights onboarding or usability friction
+
+**Dashboard Retirement Rate**
+Ratio of dashboards archived or deleted vs created.
+- Healthy signal of curation
+- Reduces clutter and cognitive overload
+
+**Interaction Signals (Proxies)**
+- Comments or annotations
+- Exports or shares
+- Alerts or subscriptions created
+
+These act as **proxies** for decision intent where direct tracking is unavailable.
+**
+Metric Definitions**
+- **Active dashboard:** Viewed at least once in the last 30 days
+- **Action:** Any follow-up indicating intent to use insights (comment, export, alert, share)
+- **Adoption window:** 30 days post-creation
+
+**Risks & Limitations**
+- Not all decisions are explicitly logged
+- Proxy signals may undercount true impact
+- Executive consumers may act offline
+
+**Mitigations**
+- Use multiple signals, not a single event
+- Segment metrics by persona where possible
+- Pair quantitative metrics with qualitative feedback
+**
+Relationship to the Core Problem**
+These metrics directly address the adoption gap identified in Issue #1 by redefining success as **insight-driven action**, not dashboard volume.


### PR DESCRIPTION
**Problem**
Dashboard creation and views are often used as success metrics, but they do not reliably indicate insight or decision-making.

**Decision**
Define adoption using outcome-based metrics that measure whether dashboards lead to actions or decisions.

 **What changed**
- Added `docs/adoption-metrics.md`
- Defined a North Star adoption metric focused on decision impact
- Documented supporting metrics, risks, and mitigations

**Expected impact**
- Reduces vanity adoption signals
- Aligns analytics usage with business value
- Creates a foundation for future solution design

Closes #2
References #1
